### PR TITLE
🐛 fix: cache issue in public links' page

### DIFF
--- a/frontend/src/app/api/public_pages/route.ts
+++ b/frontend/src/app/api/public_pages/route.ts
@@ -1,6 +1,8 @@
 import {NextRequest, NextResponse} from "next/server";
 
 export async function GET(request: NextRequest) {
+  console.log("INFO: API Request {", request.nextUrl.pathname, request.nextUrl.searchParams.get("alias")+ "}");
+  
   if (
     !request.headers
       .get("Authorization")
@@ -21,6 +23,7 @@ export async function GET(request: NextRequest) {
       }
     );
   }
+
   const apiResponse = await fetch(
     process.env.NEXT_BACKEND_API_URL +
       "pages/" +

--- a/frontend/src/lib/hooks/usePages.tsx
+++ b/frontend/src/lib/hooks/usePages.tsx
@@ -8,6 +8,7 @@ export const getPageBySlug = async (slug: string): Promise<LinksPage> => {
                 "Content-Type": "application/json",
                 Authorization: `Bearer ${process.env.NEXT_FRONTEND_API_KEY}`,
             },
+            cache: "no-cache",
         });
         const data = await response.json();
         return data as LinksPage;


### PR DESCRIPTION
– Added cache header option: "no-cache" to getPageBySlug(slug: string) at usePages hook to fix the issue of the cache preventing the exhibition of updated API router data.